### PR TITLE
AST-236: Merge asset csv files (assets + variations) into 1 files compatible with CSV to Asset

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,10 @@
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=b2c78bf3e68a80912087a764c89bf7c7
+###< symfony/framework-bundle ###
+
+AKENEO_API_BASE_URI=
+AKENEO_API_CLIENT_ID=
+AKENEO_API_CLIENT_SECRET=
+AKENEO_API_USERNAME=
+AKENEO_API_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Cache and logs (Symfony2)
+/app/cache/*
+/app/logs/*
+!app/cache/.gitkeep
+!app/logs/.gitkeep
+
+# Email spool folder
+/app/spool/*
+
+# Cache, session files and logs (Symfony3)
+/var/cache/*
+/var/logs/*
+/var/sessions/*
+!var/cache/.gitkeep
+!var/logs/.gitkeep
+!var/sessions/.gitkeep
+
+# Logs (Symfony4)
+/var/log/*
+!var/log/.gitkeep
+
+# Parameters
+/app/config/parameters.yml
+/app/config/parameters.ini
+
+# Managed by Composer
+/app/bootstrap.php.cache
+/var/bootstrap.php.cache
+/bin/*
+!bin/console
+!bin/symfony_requirements
+/vendor/
+
+# Assets and user uploads
+/web/bundles/
+/web/uploads/
+
+# PHPUnit
+/app/phpunit.xml
+/phpunit.xml
+
+# Build data
+/build/
+
+# Composer PHAR
+/composer.phar
+
+# Backup entities generated with doctrine:generate:entities command
+**/Entity/*~
+
+# Embedded web-server pid file
+/.web-server-pid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.4'
+
+services:
+  php:
+    image: 'akeneo/pim-dev/php:7.3'
+    environment:
+      APP_ENV: '${APP_ENV:-prod}'
+      COMPOSER_HOME: '/var/www/.composer'
+      PHP_IDE_CONFIG: 'serverName=csv-to-asset'
+    volumes:
+      - './:/srv/csv-to-asset'
+      - '${HOST_COMPOSER_HOME:-~/.composer}:/var/www/.composer'
+    working_dir: '/srv/csv-to-asset'
+    command: 'php'
+    networks:
+      - 'csv-to-asset'
+
+networks:
+  csv-to-asset:

--- a/src/Command/CreateFamilyCommand.php
+++ b/src/Command/CreateFamilyCommand.php
@@ -52,8 +52,8 @@ class CreateFamilyCommand extends Command
             'labels' => ['en_US' => $this->assetFamilyCode], // TODO AST-239 Need to set at least 1 label, else the UI fail :/
         ]);
 
-        $this->createAttribute('reference', 'media_file', false, false, false);
-        $this->createAttribute('reference_localizable', 'media_file', true, false, false);
+        $this->createAttribute('reference', 'media_file', false, true, false);
+        $this->createAttribute('reference_localizable', 'media_file', true, true, false);
         $this->createAttribute('variation_scopable', 'media_file', false, true, false);
         $this->createAttribute('variation_localizable_scopable', 'media_file', true, true, false);
         $this->createAttribute('description', 'text', false, false, false);

--- a/src/Command/MergeAssetsAndVariationsFilesCommand.php
+++ b/src/Command/MergeAssetsAndVariationsFilesCommand.php
@@ -204,6 +204,9 @@ class MergeAssetsAndVariationsFilesCommand extends Command
                 $this->locales[] = $variationLine['locale'];
             }
         }
+
+        $this->channels = array_filter($this->channels);
+        $this->locales = array_filter($this->locales);
     }
 
     /**

--- a/src/Command/MergeAssetsAndVariationsFilesCommand.php
+++ b/src/Command/MergeAssetsAndVariationsFilesCommand.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Reader\CsvReader;
+use Box\Spout\Common\Exception\IOException;
+use Box\Spout\Common\Exception\UnsupportedTypeException;
+use Box\Spout\Common\Type;
+use Box\Spout\Reader\Exception\ReaderNotOpenedException;
+use Box\Spout\Writer\CSV\Writer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Box\Spout\Writer\WriterFactory;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MergeAssetsAndVariationsFilesCommand extends Command
+{
+    protected static $defaultName = 'app:merge-files';
+
+    private const CSV_FIELD_DELIMITER = ';';
+    private const CSV_FIELD_ENCLOSURE = '"';
+    private const CSV_END_OF_LINE_CHARACTER = "\n";
+
+    /** @var SymfonyStyle */
+    private $io;
+
+    /** @var CsvReader */
+    private $assetsReader;
+
+    /** @var CsvReader */
+    private $variationsReader;
+
+    /** @var string[] */
+    private $channels = [];
+
+    /** @var string[] */
+    private $locales = [];
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Merge Assets & Variations CSV files into one')
+            ->addArgument('assetsFilePath', InputArgument::REQUIRED, 'Path to the Assets CSV file')
+            ->addArgument('variationsFilePath', InputArgument::REQUIRED, 'Path to the Variations CSV file path')
+            ->addArgument('targetFilePath', InputArgument::REQUIRED, 'The filePath to the new CSV file to create.')
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->io = new SymfonyStyle($input, $output);
+
+        $assetsFilePath = $input->getArgument('assetsFilePath');
+        $variationsFilePath = $input->getArgument('variationsFilePath');
+        $targetFilePath = $input->getArgument('targetFilePath');
+
+        $this->io->title('Merge PAM Assets CSV file with PAM Variation CSV file');
+        $this->io->text(
+            sprintf('This command will merge a given PAM Asset CSV file with a given Variations CSV file into one single file: "%s"', $targetFilePath)
+        );
+
+        $hasValidFilePaths = $this->hasValidFilePaths($assetsFilePath, $variationsFilePath);
+        if (!$hasValidFilePaths) {
+            return 1;
+        }
+
+        try {
+            $this->assetsReader = new CsvReader(
+                $assetsFilePath, [
+                    'fieldDelimiter' => self::CSV_FIELD_DELIMITER,
+                    'fieldEnclosure' => self::CSV_FIELD_ENCLOSURE,
+                    'endOfLineCharacter' => self::CSV_END_OF_LINE_CHARACTER,
+                ]
+            );
+
+            $this->variationsReader = new CsvReader(
+                $variationsFilePath, [
+                    'fieldDelimiter' => self::CSV_FIELD_DELIMITER,
+                    'fieldEnclosure' => self::CSV_FIELD_ENCLOSURE,
+                    'endOfLineCharacter' => self::CSV_END_OF_LINE_CHARACTER,
+                ]
+            );
+        } catch (IOException|UnsupportedTypeException|ReaderNotOpenedException $e) {
+            $this->io->error($e->getMessage());
+
+            exit;
+        }
+
+        $this->io->text('');
+
+        $this->io->text('Now merging files and create new Assets...');
+        $this->retrieveChannelsAndLocales();
+        $this->mergeFiles($output, $targetFilePath);
+        $this->io->success(sprintf('%s assets created in "%s"', $this->assetsReader->count(), $targetFilePath));
+    }
+
+    private function mergeFiles(OutputInterface $output, string $targetFilePath)
+    {
+        $progressBar = new ProgressBar($output, $this->assetsReader->count());
+        $progressBar->start();
+
+        /** @var Writer $writer */
+        $writer = WriterFactory::create(Type::CSV);
+        $writer->setFieldDelimiter(self::CSV_FIELD_DELIMITER);
+        $writer->setFieldEnclosure(self::CSV_FIELD_ENCLOSURE);
+        $writer->openToFile($targetFilePath);
+        $writer->addRow($this->getAssetManagerFileHeaders());
+
+        foreach ($this->assetsReader as $assetLineNumber => $row) {
+            if ($assetLineNumber === 1) {
+                continue;
+            }
+
+            if (!$this->isHeaderValid($this->assetsReader, $row)) {
+                continue;
+            }
+
+            $assetLine = array_combine($this->assetsReader->getHeaders(), $row);
+
+            $variationsForThisAsset = [];
+            foreach ($this->variationsReader as $variationLineNumber => $variationRow) {
+                if ($variationLineNumber === 1) {
+                    continue;
+                }
+
+                if (!$this->isHeaderValid($this->variationsReader, $variationRow)) {
+                    continue;
+                }
+
+                $variationLine = array_combine($this->variationsReader->getHeaders(), $variationRow);
+
+                if ($variationLine['asset'] === $assetLine['code']) {
+                    $variationsForThisAsset[] = $variationLine;
+                }
+            }
+
+            $newAsset = $this->mergeAssetAndVariations($assetLine, $variationsForThisAsset);
+
+            $writer->addRow($newAsset);
+            $progressBar->advance();
+        }
+
+        $writer->close();
+        $progressBar->finish();
+    }
+
+    private function isHeaderValid(CsvReader $reader, $row)
+    {
+        return count($reader->getHeaders()) === count($row);
+    }
+
+    /**
+     * The new file Headers are a merge between the Asset CSV file headers and the generated value keys
+     * computed from the Variation CSV file headers (attribute-channel-locale)
+     */
+    private function getAssetManagerFileHeaders(): array
+    {
+        $assetHeaders = $this->assetsReader->getHeaders();
+        $valuesHeaders = [];
+        foreach ($this->channels as $channel) {
+            $valuesHeaders[] = sprintf('reference_file-%s', $channel);
+            $valuesHeaders[] = sprintf('variation_file-%s', $channel);
+
+            foreach ($this->locales as $locale) {
+                $valuesHeaders[] = sprintf('reference_file-%s-%s', $channel, $locale);
+                $valuesHeaders[] = sprintf('variation_file-%s-%s', $channel, $locale);
+            }
+        }
+
+        return array_merge($assetHeaders, $valuesHeaders);
+    }
+
+    /**
+     * Retrieve Channels & Locales we'll need to write the new Assets values for.
+     */
+    private function retrieveChannelsAndLocales(): void
+    {
+        foreach ($this->variationsReader as $variationLineNumber => $variationRow) {
+            if ($variationLineNumber === 1) {
+                continue;
+            }
+
+            if (!$this->isVariationsHeaderValid($variationRow)) {
+                continue;
+            }
+
+            $variationLine = array_combine($this->variationsReader->getHeaders(), $variationRow);
+
+            if (!in_array($variationLine['channel'], $this->channels)) {
+                $this->channels[] = $variationLine['channel'];
+            }
+
+            if (!in_array($variationLine['locale'], $this->locales)) {
+                $this->locales[] = $variationLine['locale'];
+            }
+        }
+    }
+
+    /**
+     * Merge and return a given $oldAsset and its $variations into a new Asset Manager asset ready to import.
+     */
+    private function mergeAssetAndVariations(array $oldAsset, array $variations): array
+    {
+        $structure = $this->getAssetManagerFileHeaders();
+        $structure = array_flip($structure);
+        
+        foreach ($variations as $variation) {
+            if (!empty($variation['locale'])) {
+                $structure[sprintf('reference_file-%s-%s', $variation['channel'], $variation['locale'])] = $variation['reference_file'];
+                $structure[sprintf('variation_file-%s-%s', $variation['channel'], $variation['locale'])] = $variation['variation_file'];
+            } else {
+                $structure[sprintf('reference_file-%s', $variation['channel'])] = $variation['reference_file'];
+                $structure[sprintf('variation_file-%s', $variation['channel'])] = $variation['variation_file'];
+            }
+        }
+
+        return array_merge($oldAsset, $structure);
+    }
+
+    /**
+     * Check if given filepaths are existing files.
+     */
+    private function hasValidFilePaths(string $assetsFilePath, string $variationsFilePath): bool
+    {
+        $hasValidFilePath = true;
+
+        if (!file_exists($assetsFilePath)) {
+            $this->io->warning(sprintf('The file "%s" does not exist.', $assetsFilePath));
+            $hasValidFilePath = false;
+        }
+
+        if (!file_exists($variationsFilePath)) {
+            $this->io->warning(sprintf('The file "%s" does not exist.', $variationsFilePath));
+            $hasValidFilePath = false;
+        }
+
+        return $hasValidFilePath;
+    }
+}

--- a/src/Command/MergeAssetsAndVariationsFilesCommand.php
+++ b/src/Command/MergeAssetsAndVariationsFilesCommand.php
@@ -215,7 +215,7 @@ class MergeAssetsAndVariationsFilesCommand extends Command
     private function mergeAssetAndVariations(array $oldAsset, array $variations): array
     {
         $structure = $this->getAssetManagerFileHeaders();
-        $structure = array_flip($structure);
+        $structure = array_fill_keys(array_keys(array_flip($structure)), null);
         
         foreach ($variations as $variation) {
             if (!empty($variation['locale'])) {
@@ -227,7 +227,7 @@ class MergeAssetsAndVariationsFilesCommand extends Command
             }
         }
 
-        return array_merge($oldAsset, $structure);
+        return array_merge($structure, $oldAsset);
     }
 
     /**

--- a/src/Command/MergeAssetsAndVariationsFilesCommand.php
+++ b/src/Command/MergeAssetsAndVariationsFilesCommand.php
@@ -190,7 +190,7 @@ class MergeAssetsAndVariationsFilesCommand extends Command
                 continue;
             }
 
-            if (!$this->isVariationsHeaderValid($variationRow)) {
+            if (!$this->isHeaderValid($this->variationsReader, $variationRow)) {
                 continue;
             }
 

--- a/src/Command/MergeAssetsAndVariationsFilesCommand.php
+++ b/src/Command/MergeAssetsAndVariationsFilesCommand.php
@@ -31,8 +31,10 @@ class MergeAssetsAndVariationsFilesCommand extends Command
     private const CSV_FIELD_ENCLOSURE = '"';
     private const CSV_END_OF_LINE_CHARACTER = "\n";
 
-    private const REFERENCE_FILE_FIELD = 'reference_file';
-    private const VARIATION_FILE_FIELD = 'variation_file';
+    private const REFERENCE_FILE_FIELD = 'reference';
+    private const VARIATION_FILE_FIELD = 'variation_scopable';
+    private const LOCALIZED_REFERENCE_FILE_FIELD = 'reference_localizable';
+    private const LOCALIZED_VARIATION_FILE_FIELD = 'variation_localizable_scopable';
 
     /** @var SymfonyStyle */
     private $io;
@@ -177,8 +179,8 @@ class MergeAssetsAndVariationsFilesCommand extends Command
             $valuesHeaders[] = sprintf('%s-%s', self::VARIATION_FILE_FIELD, $channel);
 
             foreach ($this->locales as $locale) {
-                $valuesHeaders[] = sprintf('%s-%s-%s', self::REFERENCE_FILE_FIELD, $channel, $locale);
-                $valuesHeaders[] = sprintf('%s-%s-%s', self::VARIATION_FILE_FIELD, $channel, $locale);
+                $valuesHeaders[] = sprintf('%s-%s-%s', self::LOCALIZED_REFERENCE_FILE_FIELD, $locale, $channel);
+                $valuesHeaders[] = sprintf('%s-%s-%s', self::LOCALIZED_VARIATION_FILE_FIELD, $locale, $channel);
             }
         }
 
@@ -224,8 +226,8 @@ class MergeAssetsAndVariationsFilesCommand extends Command
         
         foreach ($variations as $variation) {
             if (!empty($variation['locale'])) {
-                $structure[sprintf('%s-%s-%s', self::REFERENCE_FILE_FIELD, $variation['channel'], $variation['locale'])] = $variation['reference_file'];
-                $structure[sprintf('%s-%s-%s', self::VARIATION_FILE_FIELD, $variation['channel'], $variation['locale'])] = $variation['variation_file'];
+                $structure[sprintf('%s-%s-%s', self::LOCALIZED_REFERENCE_FILE_FIELD, $variation['locale'], $variation['channel'])] = $variation['reference_file'];
+                $structure[sprintf('%s-%s-%s', self::LOCALIZED_VARIATION_FILE_FIELD, $variation['locale'], $variation['channel'])] = $variation['variation_file'];
             } else {
                 $structure[sprintf('%s-%s', self::REFERENCE_FILE_FIELD, $variation['channel'])] = $variation['reference_file'];
                 $structure[sprintf('%s-%s', self::VARIATION_FILE_FIELD, $variation['channel'])] = $variation['variation_file'];

--- a/src/Command/MergeAssetsAndVariationsFilesCommand.php
+++ b/src/Command/MergeAssetsAndVariationsFilesCommand.php
@@ -31,6 +31,9 @@ class MergeAssetsAndVariationsFilesCommand extends Command
     private const CSV_FIELD_ENCLOSURE = '"';
     private const CSV_END_OF_LINE_CHARACTER = "\n";
 
+    private const REFERENCE_FILE_FIELD = 'reference_file';
+    private const VARIATION_FILE_FIELD = 'variation_file';
+
     /** @var SymfonyStyle */
     private $io;
 
@@ -65,9 +68,10 @@ class MergeAssetsAndVariationsFilesCommand extends Command
         $targetFilePath = $input->getArgument('targetFilePath');
 
         $this->io->title('Merge PAM Assets CSV file with PAM Variation CSV file');
-        $this->io->text(
-            sprintf('This command will merge a given PAM Asset CSV file with a given Variations CSV file into one single file: "%s"', $targetFilePath)
-        );
+        $this->io->text([
+            sprintf('This command will merge a given PAM Asset CSV file with a given Variations CSV file into one single file: "%s"', $targetFilePath),
+            'This file will be importable via the command "app:import"'
+        ]);
 
         $hasValidFilePaths = $this->hasValidFilePaths($assetsFilePath, $variationsFilePath);
         if (!$hasValidFilePaths) {
@@ -102,6 +106,7 @@ class MergeAssetsAndVariationsFilesCommand extends Command
         $this->retrieveChannelsAndLocales();
         $this->mergeFiles($output, $targetFilePath);
         $this->io->success(sprintf('%s assets created in "%s"', $this->assetsReader->count(), $targetFilePath));
+        $this->io->text('You can now import it directly into your PIM by running the "app:import" command');
     }
 
     private function mergeFiles(OutputInterface $output, string $targetFilePath)
@@ -168,12 +173,12 @@ class MergeAssetsAndVariationsFilesCommand extends Command
         $assetHeaders = $this->assetsReader->getHeaders();
         $valuesHeaders = [];
         foreach ($this->channels as $channel) {
-            $valuesHeaders[] = sprintf('reference_file-%s', $channel);
-            $valuesHeaders[] = sprintf('variation_file-%s', $channel);
+            $valuesHeaders[] = sprintf('%s-%s', self::REFERENCE_FILE_FIELD, $channel);
+            $valuesHeaders[] = sprintf('%s-%s', self::VARIATION_FILE_FIELD, $channel);
 
             foreach ($this->locales as $locale) {
-                $valuesHeaders[] = sprintf('reference_file-%s-%s', $channel, $locale);
-                $valuesHeaders[] = sprintf('variation_file-%s-%s', $channel, $locale);
+                $valuesHeaders[] = sprintf('%s-%s-%s', self::REFERENCE_FILE_FIELD, $channel, $locale);
+                $valuesHeaders[] = sprintf('%s-%s-%s', self::VARIATION_FILE_FIELD, $channel, $locale);
             }
         }
 
@@ -219,11 +224,11 @@ class MergeAssetsAndVariationsFilesCommand extends Command
         
         foreach ($variations as $variation) {
             if (!empty($variation['locale'])) {
-                $structure[sprintf('reference_file-%s-%s', $variation['channel'], $variation['locale'])] = $variation['reference_file'];
-                $structure[sprintf('variation_file-%s-%s', $variation['channel'], $variation['locale'])] = $variation['variation_file'];
+                $structure[sprintf('%s-%s-%s', self::REFERENCE_FILE_FIELD, $variation['channel'], $variation['locale'])] = $variation['reference_file'];
+                $structure[sprintf('%s-%s-%s', self::VARIATION_FILE_FIELD, $variation['channel'], $variation['locale'])] = $variation['variation_file'];
             } else {
-                $structure[sprintf('reference_file-%s', $variation['channel'])] = $variation['reference_file'];
-                $structure[sprintf('variation_file-%s', $variation['channel'])] = $variation['variation_file'];
+                $structure[sprintf('%s-%s', self::REFERENCE_FILE_FIELD, $variation['channel'])] = $variation['reference_file'];
+                $structure[sprintf('%s-%s', self::VARIATION_FILE_FIELD, $variation['channel'])] = $variation['variation_file'];
             }
         }
 

--- a/src/Processor/Converter/MediaAttributeConverter.php
+++ b/src/Processor/Converter/MediaAttributeConverter.php
@@ -35,41 +35,6 @@ class MediaAttributeConverter implements DataConverterInterface
 
     public function convert(array $attribute, string $data, array $context)
     {
-        $mediaFilePath = $this->mediaFilePath($data, $context);
-        $this->checkMediaExists($mediaFilePath);
-        $mediaIdentifier = $this->uploadMediaToPIM($mediaFilePath);
-
-        return $mediaIdentifier;
-    }
-
-    private function mediaFilePath(string $relativeMediaPath, array $context): string
-    {
-        $fileToImportPath = $context['filePath'];
-
-        return sprintf('%s%s%s', dirname($fileToImportPath), DIRECTORY_SEPARATOR, $relativeMediaPath);
-    }
-
-    private function checkMediaExists(string $mediaFilePath): void
-    {
-        if (!$this->filesystem->exists($mediaFilePath)) {
-            throw new \RuntimeException(sprintf('media file at path "%s" was not found.', $mediaFilePath));
-        }
-    }
-
-    private function uploadMediaToPIM(string $mediaFilePath): string
-    {
-        try {
-            $mediaIdentifier = $this->pimClient->getReferenceEntityMediaFileApi()->create($mediaFilePath);
-
-            return $mediaIdentifier;
-        } catch (\Exception $exception) {
-            $message = sprintf(
-                'An error occured while uploading the media at path "%s" to the PIM: %s',
-                $mediaFilePath,
-                $exception->getMessage()
-            );
-
-            throw new \RuntimeException($message);
-        }
+        return $data;
     }
 }

--- a/src/Processor/Converter/MediaAttributeConverter.php
+++ b/src/Processor/Converter/MediaAttributeConverter.php
@@ -14,7 +14,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class MediaAttributeConverter implements DataConverterInterface
 {
-    private const IMAGE_ATTRIBUTE_TYPE = 'image';
+    private const IMAGE_ATTRIBUTE_TYPE = 'media_file';
 
     /** @var AkeneoPimEnterpriseClientInterface */
     private $pimClient;


### PR DESCRIPTION
This command merges the 2 files `assets.csv` & `variations.csv` into one file ready to be imported via the CsvToAsset command.

![yiL6IWv](https://user-images.githubusercontent.com/301169/72075572-53596d00-32f4-11ea-8109-6d46ab6cae29.png)

This is the kind of file we end up with:
![e4rzfnX](https://user-images.githubusercontent.com/301169/72077629-da5c1480-32f7-11ea-97bc-f54297299d6d.png)

