### PR TITLE
AST-438: Fix logs

### DIFF
--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -208,7 +208,8 @@ class ImportCommand extends Command
             $this->io->text(
                 'They are either not defined in your PIM for this Asset manager, or their context is not valid (channel or locale unrecognized)'
             );
-
+        }
+        if (count($unsupportedHeaders) > 0) {
             $this->io->title('The following properties are not supported by this tool and will be skipped:');
             $this->io->listing($unsupportedHeaders);
             $this->io->text(


### PR DESCRIPTION
We would print the message that some converters were not found even when the header is only invalid

Before:
```
The following properties won't be imported by this tool:
========================================================

 * localized

 They are either not defined in your PIM for this Asset manager, or their context is not valid (channel or locale unrecognized)

The following properties are not supported by this tool and will be skipped:
============================================================================


 There is no converter registered that supports these attributes
```

After:
```
The following properties won't be imported by this tool:
========================================================

 * localized

 They are either not defined in your PIM for this Asset manager, or their context is not valid (channel or locale unrecognized)
```