### PR TITLE
MET-65: In PAM migration tool, the reference attribute shouldn't have a value per channel

### DIFF
--- a/src/Command/CreateFamilyCommand.php
+++ b/src/Command/CreateFamilyCommand.php
@@ -255,7 +255,7 @@ class CreateFamilyCommand extends Command
 
     private function createNonLocalizableAttributes(string $withVariations): void
     {
-        $this->createAttribute($this->fieldNameProvider->get(FieldNameProvider::REFERENCE), 'media_file', false, true, false);
+        $this->createAttribute($this->fieldNameProvider->get(FieldNameProvider::REFERENCE), 'media_file', false, false, false);
         if ($withVariations === self::YES) {
             $this->createAttribute($this->fieldNameProvider->get(FieldNameProvider::VARIATION_SCOPABLE), 'media_file', false, true, false);
         } else {
@@ -265,7 +265,7 @@ class CreateFamilyCommand extends Command
 
     private function createLocalizableAttributes(string $withVariations): void
     {
-        $this->createAttribute($this->fieldNameProvider->get(FieldNameProvider::REFERENCE_LOCALIZABLE), 'media_file', true, true, false);
+        $this->createAttribute($this->fieldNameProvider->get(FieldNameProvider::REFERENCE_LOCALIZABLE), 'media_file', true, false, false);
         if ($withVariations === self::YES) {
             $this->createAttribute($this->fieldNameProvider->get(FieldNameProvider::VARIATION_LOCALIZABLE_SCOPABLE), 'media_file', true, true, false);
         } else {

--- a/src/Command/MergeAssetsAndVariationsFilesCommand.php
+++ b/src/Command/MergeAssetsAndVariationsFilesCommand.php
@@ -276,7 +276,7 @@ class MergeAssetsAndVariationsFilesCommand extends Command
 
         foreach ($this->channels as $channel) {
             if ($this->referenceType === self::NON_LOCALIZABLE || $this->referenceType === self::BOTH) {
-                $valuesHeaders[] = sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE), $channel);
+                $valuesHeaders[] = sprintf('%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE));
                 if ($this->withVariations === self::YES) {
                     $valuesHeaders[] = sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::VARIATION_SCOPABLE), $channel);
                 }
@@ -284,7 +284,7 @@ class MergeAssetsAndVariationsFilesCommand extends Command
 
             if ($this->referenceType === self::LOCALIZABLE || $this->referenceType === self::BOTH) {
                 foreach ($this->locales as $locale) {
-                    $valuesHeaders[] = sprintf('%s-%s-%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE_LOCALIZABLE), $locale, $channel);
+                    $valuesHeaders[] = sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE_LOCALIZABLE), $locale);
                     if ($this->withVariations === self::YES) {
                         $valuesHeaders[] = sprintf('%s-%s-%s', $this->fieldNameProvider->get(FieldNameProvider::VARIATION_LOCALIZABLE_SCOPABLE), $locale, $channel);
                     }
@@ -338,7 +338,7 @@ class MergeAssetsAndVariationsFilesCommand extends Command
         foreach ($variations as $variation) {
             if (!empty($variation['locale'])) {
                 if ($this->referenceType === self::LOCALIZABLE || $this->referenceType === self::BOTH) {
-                    $mappedStructure[sprintf('%s-%s-%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE_LOCALIZABLE), $variation['locale'], $variation['channel'])] = $variation['reference_file'];
+                    $mappedStructure[sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE_LOCALIZABLE), $variation['locale'])] = $variation['reference_file'];
                     if ($this->withVariations === self::YES) {
                         $mappedStructure[sprintf('%s-%s-%s', $this->fieldNameProvider->get(FieldNameProvider::VARIATION_LOCALIZABLE_SCOPABLE), $variation['locale'], $variation['channel'])] = $variation['variation_file'];
                     }
@@ -352,16 +352,18 @@ class MergeAssetsAndVariationsFilesCommand extends Command
                 }
             } else {
                 if ($this->referenceType === self::NON_LOCALIZABLE || $this->referenceType === self::BOTH) {
-                    $mappedStructure[sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE), $variation['channel'])] = $variation['reference_file'];
+                    $mappedStructure[sprintf('%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE))] = $variation['reference_file'];
                     if ($this->withVariations === self::YES) {
                         $mappedStructure[sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::VARIATION_SCOPABLE), $variation['channel'])] = $variation['variation_file'];
                     }
                 } else {
-                    throw new \RuntimeException(sprintf(
-                        "The merge script encountered an issue with \"%s\".
+                    throw new \RuntimeException(
+                        sprintf(
+                            "The merge script encountered an issue with \"%s\".
                         \nThis line does not contains any value in the locale column, but this value is needed for the asset family.",
-                        json_encode($variation)
-                    ));
+                            json_encode($variation)
+                        )
+                    );
                 }
             }
         }

--- a/src/Command/MergeAssetsAndVariationsFilesCommand.php
+++ b/src/Command/MergeAssetsAndVariationsFilesCommand.php
@@ -274,17 +274,22 @@ class MergeAssetsAndVariationsFilesCommand extends Command
             }
         }
 
+        // Reference attributes
+        if ($this->referenceType === self::NON_LOCALIZABLE || $this->referenceType === self::BOTH) {
+            $valuesHeaders[] = sprintf('%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE));
+        }
+        foreach ($this->locales as $locale) {
+            $valuesHeaders[] = sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE_LOCALIZABLE), $locale);
+        }
+
+        // Variation attributes
         foreach ($this->channels as $channel) {
-            if ($this->referenceType === self::NON_LOCALIZABLE || $this->referenceType === self::BOTH) {
-                $valuesHeaders[] = sprintf('%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE));
-                if ($this->withVariations === self::YES) {
-                    $valuesHeaders[] = sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::VARIATION_SCOPABLE), $channel);
-                }
+            if ($this->withVariations === self::YES) {
+                $valuesHeaders[] = sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::VARIATION_SCOPABLE), $channel);
             }
 
             if ($this->referenceType === self::LOCALIZABLE || $this->referenceType === self::BOTH) {
                 foreach ($this->locales as $locale) {
-                    $valuesHeaders[] = sprintf('%s-%s', $this->fieldNameProvider->get(FieldNameProvider::REFERENCE_LOCALIZABLE), $locale);
                     if ($this->withVariations === self::YES) {
                         $valuesHeaders[] = sprintf('%s-%s-%s', $this->fieldNameProvider->get(FieldNameProvider::VARIATION_LOCALIZABLE_SCOPABLE), $locale, $channel);
                     }


### PR DESCRIPTION
In PAM migration tool, the reference attribute shouldn't have a value per channel