### PR TITLE
Fix doc & support media links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Then open `.env` to define the needed configuration vars:
 - `APP_ENV` refers to the `APP_ENV` of your PIM Enterprise Edition, used for direct bask calls.
    Set it to `prod`, `prod_onprem_paas`...
 
+You also need to create a `credentials` file at the root of this project. This API credentials file needs to contain the following information : `clientId`, `secret`, `username`, `password`. The format of the file is the given in the example below :
+```
+on this line put my API client ID
+on this line put my API secret
+on this line put my API username
+on this line put my API password
+```
+
 ## Docker setup
 
 First, you have to update your Enterprise Edition `docker-compose.yml` file to allow external data from network.

--- a/src/Processor/Converter/TextAttributeConverter.php
+++ b/src/Processor/Converter/TextAttributeConverter.php
@@ -18,7 +18,7 @@ class TextAttributeConverter implements DataConverterInterface
      */
     public function support(array $attribute): bool
     {
-        return isset($attribute['type']) && 'text' === $attribute['type'];
+        return isset($attribute['type']) && ('text' === $attribute['type'] || 'media_link' === $attribute['type']);
     }
 
     /**

--- a/tests/specs/Processor/Converter/TextAttributeConverterSpec.php
+++ b/tests/specs/Processor/Converter/TextAttributeConverterSpec.php
@@ -23,6 +23,12 @@ class TextAttributeConverterSpec extends ObjectBehavior
         $this->support($attribute)->shouldReturn(true);
     }
 
+    function it_also_supports_media_links_attribute()
+    {
+        $attribute = ['type' => 'media_link'];
+        $this->support($attribute)->shouldReturn(true);
+    }
+
     function it_converts_data_for_a_specific_attribute()
     {
         $attribute = ['type' => 'text'];


### PR DESCRIPTION
Currently it's impossible to import media link attributes via CSV files. This PR fixes the problem.

The PR works. I just used it to import a CSV file into a Serenity preprod.